### PR TITLE
[FEAT] 쿼리 로그를 위한 log4jdbc 적용 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 *.yml
 *.yaml
 *.properties
+!src/main/resources/log4jdbc.log4j2.properties
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	def queryDslVersion = "5.0.0"
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"	// buildscript에서 적용한 변수가 여기에 적용
 	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+	// log4jdbc
+	implementation group: 'org.bgee.log4jdbc-log4j2', name: 'log4jdbc-log4j2-jdbc4.1', version: '1.16'
 }
 
 tasks.named('test') {
@@ -62,5 +65,6 @@ configurations {													// build 옵션
 	}
 	querydsl.extendsFrom compileClasspath							// querydsl이 compileClasspath를 상속하도록 설정
 }
+
 
 

--- a/src/main/resources/log4jdbc.log4j2.properties
+++ b/src/main/resources/log4jdbc.log4j2.properties
@@ -1,0 +1,5 @@
+# \uB450\uAC00\uC9C0 \uC124\uC815 \uB354 \uD544\uC694
+# spring.datasource.url=jdbc:log4jdbc:mysql:~~~~ (jdbc\uC640 mysql \uC0AC\uC774\uC5D0 log4jdbc \uCD94\uAC00)
+# spring.datasource.driver-class-name=net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+log4jdbc.spylogdelegator.name=net.sf.log4jdbc.log.slf4j.Slf4jSpyLogDelegator
+log4jdbc.dump.sql.maxlinelength=0

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyyMMdd HH:mm:ss.SSS} [%thread] %-3level %logger{5} - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="jdbc" level="OFF"/>
+    <logger name="jdbc.sqlonly" level="OFF"/>
+    <logger name="jdbc.audit" level="OFF"/>
+    <logger name="jdbc.resultset" level="OFF"/>
+<!--    <logger name="jdbc.resultsettable" level="DEBUG"/>-->
+    <logger name="jdbc.resultsettable" level="OFF"/>
+    <logger name="jdbc.sqltiming" level="DEBUG"/>
+    <logger name="jdbc.connection" level="OFF"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feature/17-> dev

### 변경 사항
- 애플리케이션을 통해 날아가는 쿼리에 대한 로그를 볼 수 있게 해주는 log4jdbc를 적용

### 테스트 결과
테스트 코드로 확인 이상 없이 잘 출력됩니다.
